### PR TITLE
Add metrics logger for body measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Local-first, offline-ready, single-page web app for logging runs, strength, fast
 - Fasting (with start/stop button)
 - Meditation/Breathing
 - parkrun (manual entry)
+- Metrics (weight, hips, waist, bust)
 
 ## Customisation
 - Basic styles in `styles.css`

--- a/app.js
+++ b/app.js
@@ -133,7 +133,8 @@
       ...list('strength').map(x => ({...x, _type:'Strength', _stamp:x.createdAt})),
       ...list('fasting').map(x => ({...x, _type:'Fasting', _stamp:x.createdAt})),
       ...list('meditation').map(x => ({...x, _type:'Meditation', _stamp:x.createdAt})),
-      ...list('parkrun').map(x => ({...x, _type:'parkrun', _stamp:x.createdAt}))
+      ...list('parkrun').map(x => ({...x, _type:'parkrun', _stamp:x.createdAt})),
+      ...list('metrics').map(x => ({...x, _type:'Metrics', _stamp:x.createdAt}))
     ].sort((a,b)=> new Date(b._stamp) - new Date(a._stamp)).slice(0,10);
     if(!rows.length) return `<p class="meta">Nothing logged yet — try the quick add forms above or visit a module from the nav.</p>`;
     return `<div class="list">` + rows.map(r => {
@@ -143,6 +144,12 @@
         if(r._type==='Fasting') return r.end ? `${Math.round((new Date(r.end)-new Date(r.start))/36e5)} h` : `Started`;
         if(r._type==='parkrun') return `${fmtTimeSeconds(r.time_sec)} · ${r.event_name}`;
         if(r._type==='Strength') return (r.exercises||[]).map(e=>`${e.name} ${e.sets}×${e.reps}@${e.load_kg||0}kg`).join(', ');
+        if(r._type==='Metrics') return [
+          r.weight_kg!=null ? `${r.weight_kg} kg` : null,
+          r.waist_cm!=null ? `Waist ${r.waist_cm} cm` : null,
+          r.hips_cm!=null ? `Hips ${r.hips_cm} cm` : null,
+          r.bust_cm!=null ? `Bust ${r.bust_cm} cm` : null
+        ].filter(Boolean).join(' · ');
         return '';
       })();
       return `<div class="row"><div><span class="badge">${r._type}</span> ${fmtDate(r.date||r.start||r._stamp)}</div><div class="meta">${right}</div></div>`;
@@ -264,6 +271,23 @@
         });
         pkForm.reset();
         render('#/parkrun');
+      });
+    }
+    // Metrics page
+    const metricsForm = document.getElementById('metricsForm');
+    if(metricsForm){
+      metricsForm.addEventListener('submit', (e)=>{
+        e.preventDefault();
+        const f = new FormData(metricsForm);
+        add('metrics', {
+          date: f.get('date'),
+          weight_kg: f.get('weight') ? Number(f.get('weight')) : null,
+          waist_cm: f.get('waist') ? Number(f.get('waist')) : null,
+          hips_cm: f.get('hips') ? Number(f.get('hips')) : null,
+          bust_cm: f.get('bust') ? Number(f.get('bust')) : null
+        });
+        metricsForm.reset();
+        render('#/metrics');
       });
     }
     // Settings page

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       <a href="#/fasting" data-link>Fasting</a>
       <a href="#/meditation" data-link>Meditation</a>
       <a href="#/parkrun" data-link>parkrun</a>
+      <a href="#/metrics" data-link>Metrics</a>
       <a href="#/settings" data-link>Settings</a>
       <a href="#/about" data-link>About</a>
     </nav>
@@ -43,6 +44,7 @@
 <script src="./modules/fasting.js"></script>
 <script src="./modules/meditation.js"></script>
 <script src="./modules/parkrun.js"></script>
+<script src="./modules/metrics.js"></script>
 <script src="./app.js"></script>
   <script>
     if ('serviceWorker' in navigator) {

--- a/lib.js
+++ b/lib.js
@@ -9,7 +9,8 @@ const defaultDB = () => ({
   strength: [],
   fasting: [],
   meditation: [],
-  parkrun: []
+  parkrun: [],
+  metrics: []
 });
 
 function loadDB(){

--- a/modules/metrics.js
+++ b/modules/metrics.js
@@ -1,0 +1,54 @@
+Views.metrics = function(){
+  FAB.set('metrics', () => {
+    const d = new Date().toISOString().slice(0,10);
+    const weight = prompt('Weight (kg)?', '');
+    if(weight===null) return;
+    const waist = prompt('Waist (cm)?', '');
+    if(waist===null) return;
+    const hips = prompt('Hips (cm)?', '');
+    if(hips===null) return;
+    const bust = prompt('Bust (cm)?', '');
+    if(bust===null) return;
+    add('metrics', {
+      date: d,
+      weight_kg: weight ? Number(weight) : null,
+      waist_cm: waist ? Number(waist) : null,
+      hips_cm: hips ? Number(hips) : null,
+      bust_cm: bust ? Number(bust) : null
+    });
+    requestRender();
+  });
+  const items = list('metrics');
+  const rows = items.map(x => `
+    <div class="row">
+      <div><strong>${fmtDate(x.date)}</strong></div>
+      <div class="meta">${[
+        x.weight_kg ? x.weight_kg + ' kg' : null,
+        x.waist_cm ? 'Waist ' + x.waist_cm + ' cm' : null,
+        x.hips_cm ? 'Hips ' + x.hips_cm + ' cm' : null,
+        x.bust_cm ? 'Bust ' + x.bust_cm + ' cm' : null
+      ].filter(Boolean).join(' · ')}
+        <button class="btn" onclick="removeItem('metrics','${x.id}'); requestRender()">Delete</button>
+      </div>
+    </div>
+  `).join('');
+  return `
+    <section class="card">
+      <h3>Metrics</h3>
+      <form id="metricsForm" onsubmit="return false">
+        <div class="grid">
+          <div class="span-6"><label>Date <input type="date" name="date" required></label></div>
+          <div class="span-6"><label>Weight (kg) <input type="number" step="0.1" name="weight"></label></div>
+        </div>
+        <div class="grid">
+          <div class="span-4"><label>Waist (cm) <input type="number" step="0.1" name="waist"></label></div>
+          <div class="span-4"><label>Hips (cm) <input type="number" step="0.1" name="hips"></label></div>
+          <div class="span-4"><label>Bust (cm) <input type="number" step="0.1" name="bust"></label></div>
+        </div>
+        <button class="btn primary" type="submit">Add metrics</button>
+      </form>
+      <div class="list">${rows || '<p class="meta">No metrics logged yet.</p>'}</div>
+    </section>
+  `;
+};
+


### PR DESCRIPTION
## Summary
- add metrics module to track weight, hips, waist and bust
- wire up navigation, storage and recent feed support for metrics entries
- document new metrics module in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad754b6a408323acf01192b0862450