### PR TITLE
Add height and BMI tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Local-first, offline-ready, single-page web app for logging runs, strength, fast
 - Fasting (with start/stop button)
 - Meditation/Breathing
 - parkrun (manual entry)
-- Metrics (weight, hips, waist, bust)
-- Stats (basic charts for runs, strength, Airofit and weight)
+- Metrics (weight, height, hips, waist, bust, BMI)
+- Stats (basic charts for runs, strength, Airofit, weight and BMI)
 
 
 ## Customisation

--- a/app.js
+++ b/app.js
@@ -6,6 +6,8 @@
   const yearEl = document.getElementById('year');
   if(yearEl) yearEl.textContent = new Date().getFullYear();
 
+  recalcBMI();
+
   function applyNavVisibility(){
     if(!nav) return;
     const p = (getSettings().pages) || {};
@@ -174,6 +176,8 @@
         ].filter(Boolean).join(' · ');
         if(r._type==='Metrics') return [
           r.weight_kg!=null ? `${r.weight_kg} kg` : null,
+          r.height_cm!=null ? `Height ${r.height_cm} cm` : null,
+          r.bmi!=null ? `BMI ${r.bmi}` : null,
           r.waist_cm!=null ? `Waist ${r.waist_cm} cm` : null,
           r.hips_cm!=null ? `Hips ${r.hips_cm} cm` : null,
           r.bust_cm!=null ? `Bust ${r.bust_cm} cm` : null
@@ -310,10 +314,12 @@
         add('metrics', {
           date: f.get('date'),
           weight_kg: f.get('weight') ? Number(f.get('weight')) : null,
+          height_cm: f.get('height') ? Number(f.get('height')) : null,
           waist_cm: f.get('waist') ? Number(f.get('waist')) : null,
           hips_cm: f.get('hips') ? Number(f.get('hips')) : null,
           bust_cm: f.get('bust') ? Number(f.get('bust')) : null
         });
+        recalcBMI();
         metricsForm.reset();
         render('#/metrics');
       });
@@ -360,6 +366,7 @@
         if(!file) return;
         try{
           await importJSON(file, { merge: !!(mergeChk && mergeChk.checked) });
+          recalcBMI();
           alert('Import complete');
           render('#/settings');
         }catch(err){

--- a/lib.js
+++ b/lib.js
@@ -135,6 +135,36 @@ function toSeconds(hhmmss){
 }
 function mafHR(age, adjust=0){ return 180 - (Number(age)||0) + (Number(adjust)||0); }
 
+function calcBMI(weightKg, heightCm){
+  if(weightKg==null || heightCm==null || heightCm<=0) return null;
+  const h = heightCm/100;
+  return Math.round((weightKg/(h*h))*10)/10;
+}
+
+function recalcBMI(){
+  const db = loadDB();
+  const metrics = db.metrics || [];
+  let currentHeight = null;
+  for(const m of metrics){
+    if(m.height_cm!=null){ currentHeight = m.height_cm; break; }
+  }
+  if(currentHeight==null) return;
+  let changed = false;
+  for(const m of metrics){
+    if(m.height_cm!=null) currentHeight = m.height_cm;
+    if(m.weight_kg!=null){
+      const bmi = calcBMI(m.weight_kg, currentHeight);
+      if(m.bmi !== bmi){
+        m.bmi = bmi;
+        if(m.height_cm==null) m.height_cm = currentHeight;
+        m.updatedAt = new Date().toISOString();
+        changed = true;
+      }
+    }
+  }
+  if(changed) saveDB(db);
+}
+
 // Router
 const Views = {}; // modules attach their render functions here
 

--- a/modules/metrics.js
+++ b/modules/metrics.js
@@ -3,6 +3,8 @@ Views.metrics = function(){
     const d = new Date().toISOString().slice(0,10);
     const weight = prompt('Weight (kg)?', '');
     if(weight===null) return;
+    const height = prompt('Height (cm)?', '');
+    if(height===null) return;
     const waist = prompt('Waist (cm)?', '');
     if(waist===null) return;
     const hips = prompt('Hips (cm)?', '');
@@ -12,10 +14,12 @@ Views.metrics = function(){
     add('metrics', {
       date: d,
       weight_kg: weight ? Number(weight) : null,
+      height_cm: height ? Number(height) : null,
       waist_cm: waist ? Number(waist) : null,
       hips_cm: hips ? Number(hips) : null,
       bust_cm: bust ? Number(bust) : null
     });
+    recalcBMI();
     requestRender();
   });
   const items = list('metrics');
@@ -24,11 +28,13 @@ Views.metrics = function(){
       <div><strong>${fmtDate(x.date)}</strong></div>
       <div class="meta">${[
         x.weight_kg ? x.weight_kg + ' kg' : null,
+        x.height_cm ? 'Height ' + x.height_cm + ' cm' : null,
+        x.bmi ? 'BMI ' + x.bmi : null,
         x.waist_cm ? 'Waist ' + x.waist_cm + ' cm' : null,
         x.hips_cm ? 'Hips ' + x.hips_cm + ' cm' : null,
         x.bust_cm ? 'Bust ' + x.bust_cm + ' cm' : null
       ].filter(Boolean).join(' · ')}
-        <button class="btn" onclick="removeItem('metrics','${x.id}'); requestRender()">Delete</button>
+        <button class="btn" onclick="removeItem('metrics','${x.id}'); recalcBMI(); requestRender()">Delete</button>
       </div>
     </div>
   `).join('');
@@ -37,8 +43,9 @@ Views.metrics = function(){
       <h3>Metrics</h3>
       <form id="metricsForm" onsubmit="return false">
         <div class="grid">
-          <div class="span-6"><label>Date <input type="date" name="date" required></label></div>
-          <div class="span-6"><label>Weight (kg) <input type="number" step="0.1" name="weight"></label></div>
+          <div class="span-4"><label>Date <input type="date" name="date" required></label></div>
+          <div class="span-4"><label>Weight (kg) <input type="number" step="0.1" name="weight"></label></div>
+          <div class="span-4"><label>Height (cm) <input type="number" step="0.1" name="height"></label></div>
         </div>
         <div class="grid">
           <div class="span-4"><label>Waist (cm) <input type="number" step="0.1" name="waist"></label></div>

--- a/modules/report.js
+++ b/modules/report.js
@@ -86,6 +86,8 @@ window.exportCSV = function({from,to,mods}){
       if(!d || d < from || d > to) return;
       const o = map[d] || (map[d] = {date:d});
       if(m.weight_kg!=null) o.weight_kg = m.weight_kg;
+      if(m.height_cm!=null) o.height_cm = m.height_cm;
+      if(m.bmi!=null) o.bmi = m.bmi;
       if(m.waist_cm!=null) o.waist_cm = m.waist_cm;
       if(m.hips_cm!=null) o.hips_cm = m.hips_cm;
       if(m.bust_cm!=null) o.bust_cm = m.bust_cm;
@@ -105,7 +107,7 @@ window.exportCSV = function({from,to,mods}){
     meditation:['meditation_duration_min','meditation_count'],
     fasting:['fasting_duration_h','fasting_count'],
     parkrun:['parkrun_time_sec','parkrun_count'],
-    metrics:['weight_kg','waist_cm','hips_cm','bust_cm']
+    metrics:['weight_kg','height_cm','bmi','waist_cm','hips_cm','bust_cm']
   };
   const cols = ['date'];
   mods.forEach(m => { (moduleCols[m]||[]).forEach(c => cols.push(c)); });

--- a/modules/stats.js
+++ b/modules/stats.js
@@ -3,12 +3,14 @@ Views.stats = function(){
   const strength = Stats.sumByDate(list('strength'), 'duration_min');
   const airofit = Stats.sumByDate(list('meditation'), 'duration_min', m => m.method === 'Airofit');
   const weight = Stats.lastByDate(list('metrics'), 'weight_kg');
+  const bmi = Stats.lastByDate(list('metrics'), 'bmi');
 
   setTimeout(() => {
     drawLine('runsChart', runs);
     drawLine('strengthChart', strength);
     drawLine('airofitChart', airofit);
     drawLine('weightChart', weight);
+    drawLine('bmiChart', bmi);
   });
 
   function section(title, id, has){
@@ -25,6 +27,7 @@ Views.stats = function(){
     ${section('Strength time (min)', 'strengthChart', strength.length)}
     ${section('Airofit time (min)', 'airofitChart', airofit.length)}
     ${section('Weight (kg)', 'weightChart', weight.length)}
+    ${section('BMI', 'bmiChart', bmi.length)}
   `;
 };
 


### PR DESCRIPTION
## Summary
- capture height with metric entries and compute BMI using new helpers
- recalc BMI on app start, import, and metric updates; show BMI in recent feed and charts
- include height and BMI in CSV export and documentation

## Testing
- `node --check app.js lib.js modules/metrics.js modules/stats.js modules/report.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aedd12556083238fd9373d46979ebd